### PR TITLE
Add Types.ButtonUpdate description to documentation

### DIFF
--- a/src/Html/Shorthand/Type.elm
+++ b/src/Html/Shorthand/Type.elm
@@ -6,7 +6,7 @@ you aren't already importing Html.Shorthand.
 @docs IdString, ClassString, UrlString, TextString
 
 # Event / handler types
-@docs EventDecodeError, FormUpdate, FieldUpdate, SelectUpdate
+@docs EventDecodeError, FormUpdate, FieldUpdate, ButtonUpdate, SelectUpdate
 
 # Element parameters
 @docs ClassParam, ClassIdParam, ClassCiteParam, AnchorParam, ModParam, ImgParam, IframeParam, EmbedParam, ObjectParam, MediaParam, VideoParam, AudioParam, InputFieldParam, InputTextParam, InputMaybeTextParam, InputFloatParam, InputMaybeFloatParam, InputIntParam, InputMaybeIntParam, InputUrlParam, InputMaybeUrlParam, ButtonParam, SelectParam, OptionParam, OutputParam, ProgressParam, MeterParam


### PR DESCRIPTION
I didn't find `ButtonUpdate`'s description in the [documentation](http://package.elm-lang.org/packages/circuithub/elm-html-shorthand/8.0.0/Html-Shorthand-Type), so I've added it.
